### PR TITLE
[Doc] Add document for IAM User

### DIFF
--- a/SETUP_IAM_USER.md
+++ b/SETUP_IAM_USER.md
@@ -1,0 +1,24 @@
+# Setup IAM User for bitrise-amazon-s3-uploader
+In order to use bitrise-amazon-s3-uploader, you need to [create an IAM User](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) and [create an access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) with this user.
+
+Following is IAM Policy example with minimal permission for bitrise-amazon-s3-uploader to work.
+
+```json
+{
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::YOUR-BUCKET-NAME/*"
+      ]
+    }
+  ],
+  "Version": "2012-10-17"
+}
+```
+
+Don't give full permission (e.g. `s3:*`) to IAM user!

--- a/step.yml
+++ b/step.yml
@@ -48,13 +48,19 @@ inputs:
     opts:
       title: "Amazon AWS Access Key"
       summary: ""
-      description: ""
+      description: |
+        Amazon AWS Access Key
+
+        See. https://github.com/scruffyfox/bitrise-amazon-s3-uploader/blob/master/SETUP_IAM_USER.md
       is_required: true
   - aws_secret_key: ""
     opts:
       title: "Amazon AWS Secret Access Key"
       summary: ""
-      description: ""
+      description: |
+        Amazon AWS Secret Access Key
+
+        See. https://github.com/scruffyfox/bitrise-amazon-s3-uploader/blob/master/SETUP_IAM_USER.md
       is_required: true
   - bucket_name: ""
     opts:


### PR DESCRIPTION
bitrise-amazon-s3-uploader requires AWS Access Key and Secret Access Key. But the description of IAM user is not written anywhere.

I've listed the minimum required permissions, as over-privileging can lead to vulnerabilities.

c.f. https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege

This minimum policy is actually working in my environment.